### PR TITLE
Adding support for using numbers as object keys, removing Value::Integer

### DIFF
--- a/core/src/codegen.rs
+++ b/core/src/codegen.rs
@@ -272,51 +272,35 @@ impl Code for ObjectMember {
                 ref value,
             } => gen.write(value),
 
-            ObjectMember::Literal {
-                ref key,
-                ref value,
-            } => {
-                gen.write(key);
-                gen.write_min(b": ", b":");
-                gen.write(value);
-            },
-
-            ObjectMember::Computed {
-                ref key,
-                ref value,
-            } => {
-                gen.write_byte(b'[');
-                gen.write(key);
-                gen.write_min(b"]: ", b"]:");
-                gen.write(value);
-            },
-
             ObjectMember::Method {
-                ref name,
+                ref key,
                 ref params,
                 ref body,
             } => {
-                gen.write(name);
+                gen.write(key);
                 gen.write_byte(b'(');
                 gen.write_list(params);
                 gen.write_min(b") {", b"){");
                 gen.write_block(body);
                 gen.write_byte(b'}');
             },
+        }
+    }
+}
 
-            ObjectMember::ComputedMethod {
-                ref name,
-                ref params,
-                ref body,
-            } => {
-                gen.write_byte(b'[');
-                gen.write(name);
-                gen.write_bytes(b"](");
-                gen.write_list(params);
-                gen.write_min(b") {", b"){");
-                gen.write_block(body);
-                gen.write_byte(b'}');
+impl Code for ObjectKey {
+    #[inline]
+    fn to_code(&self, gen: &mut Generator) {
+        match *self {
+            ObjectKey::Computed (ref expression) => {
+                gen.write(expression)
             },
+            ObjectKey::Literal (ref slice) => {
+                gen.write(slice)
+            },
+            ObjectKey::Binary (ref num) => {
+                gen.write(num)
+            }
         }
     }
 }

--- a/core/src/codegen.rs
+++ b/core/src/codegen.rs
@@ -251,7 +251,7 @@ impl Code for Value {
             Value::Null                => gen.write_bytes(b"null"),
             Value::True                => gen.write_min(b"true", b"!0",),
             Value::False               => gen.write_min(b"false", b"!1"),
-            Value::Integer(ref num)    => gen.write(num),
+            Value::Binary(ref num)     => gen.write(num),
             Value::Number(ref num)     => gen.write(num),
             Value::String(ref string)  => gen.write(string),
             Value::RawQuasi(ref quasi) => write_quasi(gen, *quasi),
@@ -266,6 +266,11 @@ impl Code for ObjectMember {
             ObjectMember::Shorthand {
                 ref key
             } => gen.write(key),
+
+            ObjectMember::Value {
+                ref key,
+                ref value,
+            } => gen.write(value),
 
             ObjectMember::Literal {
                 ref key,

--- a/core/src/grammar.rs
+++ b/core/src/grammar.rs
@@ -6,7 +6,6 @@ pub enum Value {
     Null,
     True,
     False,
-    Integer(u64),
     Number(OwnedSlice),
     String(OwnedSlice),
     RawQuasi(OwnedSlice),

--- a/core/src/grammar.rs
+++ b/core/src/grammar.rs
@@ -7,8 +7,16 @@ pub enum Value {
     True,
     False,
     Number(OwnedSlice),
+    Binary(u64),
     String(OwnedSlice),
     RawQuasi(OwnedSlice),
+}
+
+#[derive(Debug, PartialEq, Clone)]
+pub enum ObjectKey {
+    Computed(Expression),
+    Literal(OwnedSlice), // taken from Identifier, Value::String or Value::Number
+    Binary(u64),
 }
 
 #[derive(Debug, PartialEq, Clone, Copy)]
@@ -366,6 +374,10 @@ impl<'a> From<&'a OwnedSlice> for Expression {
 pub enum ObjectMember {
     Shorthand {
         key: OwnedSlice,
+    },
+    Value {
+        key: ObjectKey,
+        value: Expression,
     },
     Literal {
         key: OwnedSlice,

--- a/core/src/grammar.rs
+++ b/core/src/grammar.rs
@@ -12,12 +12,6 @@ pub enum Value {
     RawQuasi(OwnedSlice),
 }
 
-#[derive(Debug, PartialEq, Clone)]
-pub enum ObjectKey {
-    Computed(Expression),
-    Literal(OwnedSlice), // taken from Identifier, Value::String or Value::Number
-    Binary(u64),
-}
 
 #[derive(Debug, PartialEq, Clone, Copy)]
 pub struct Parameter {
@@ -379,24 +373,18 @@ pub enum ObjectMember {
         key: ObjectKey,
         value: Expression,
     },
-    Literal {
-        key: OwnedSlice,
-        value: Expression,
-    },
-    Computed {
-        key: Expression,
-        value: Expression,
-    },
     Method {
-        name: OwnedSlice,
+        key: ObjectKey,
         params: Vec<Parameter>,
         body: Vec<Statement>,
     },
-    ComputedMethod {
-        name: Expression,
-        params: Vec<Parameter>,
-        body: Vec<Statement>,
-    }
+}
+
+#[derive(Debug, PartialEq, Clone)]
+pub enum ObjectKey {
+    Computed(Expression),
+    Literal(OwnedSlice),
+    Binary(u64),
 }
 
 #[derive(Debug, PartialEq, Clone)]

--- a/core/src/parser.rs
+++ b/core/src/parser.rs
@@ -172,7 +172,7 @@ impl<'a> Parser<'a> {
     #[inline]
     fn object_member(&mut self, token: Token) -> Result<ObjectMember> {
         Ok(match token {
-            Identifier(key) | Literal(Value::String(key)) => {
+            Identifier(key) | Literal(Value::String(key)) | Literal(Value::Number(key)) => {
                 match peek!(self) {
                     Colon => {
                         self.consume();

--- a/core/src/parser.rs
+++ b/core/src/parser.rs
@@ -198,6 +198,33 @@ impl<'a> Parser<'a> {
                     }
                 }
             },
+            Literal(Value::Binary(num)) => {
+                let key = unsafe { OwnedSlice::from_str(&num.to_string()) };
+                match peek!(self) {
+                    Colon => {
+                        self.consume();
+
+                        ObjectMember::Literal {
+                            key: key,
+                            value: try!(self.expression(0)),
+                        }
+                    },
+
+                    ParenOpen => {
+                        self.consume();
+
+                        ObjectMember::Method {
+                            name: key,
+                            params: try!(self.parameter_list()),
+                            body: try!(self.block_body())
+                        }
+                    },
+
+                    _ => ObjectMember::Shorthand {
+                        key: key,
+                    }
+                }
+            },
             BracketOpen => {
                 let key = try!(self.expression(0));
 

--- a/core/src/tokenizer.rs
+++ b/core/src/tokenizer.rs
@@ -1034,7 +1034,9 @@ impl<'a> Tokenizer<'a> {
             }
         }
 
-        Value::Integer(value)
+        Value::Number(unsafe {
+            OwnedSlice::from_str(&value.to_string())
+        })
     }
 
     #[inline]
@@ -1052,7 +1054,9 @@ impl<'a> Tokenizer<'a> {
             self.bump();
         }
 
-        Value::Integer(value)
+        Value::Number(unsafe {
+            OwnedSlice::from_str(&value.to_string())
+        })
     }
 
     #[inline]
@@ -1072,7 +1076,9 @@ impl<'a> Tokenizer<'a> {
             self.bump();
         }
 
-        Value::Integer(value)
+        Value::Number(unsafe {
+            OwnedSlice::from_str(&value.to_string())
+        })
     }
 
     #[inline]

--- a/core/src/tokenizer.rs
+++ b/core/src/tokenizer.rs
@@ -1034,9 +1034,7 @@ impl<'a> Tokenizer<'a> {
             }
         }
 
-        Value::Number(unsafe {
-            OwnedSlice::from_str(&value.to_string())
-        })
+        Value::Binary(value)
     }
 
     #[inline]
@@ -1055,7 +1053,8 @@ impl<'a> Tokenizer<'a> {
         }
 
         Value::Number(unsafe {
-            OwnedSlice::from_str(&value.to_string())
+            let num = value.to_owned().to_string();
+            OwnedSlice::from_str(&num)
         })
     }
 
@@ -1077,7 +1076,8 @@ impl<'a> Tokenizer<'a> {
         }
 
         Value::Number(unsafe {
-            OwnedSlice::from_str(&value.to_string())
+            let num = value.to_owned().to_string();
+            OwnedSlice::from_str(&num)
         })
     }
 

--- a/core/src/tokenizer.rs
+++ b/core/src/tokenizer.rs
@@ -668,13 +668,13 @@ define_handlers! {
             b'o' | b'O' => {
                 tok.bump();
 
-                return Ok(Literal(tok.read_octal()));
+                return Ok(Literal(tok.read_octal(start)));
             },
 
             b'x' | b'X' => {
                 tok.bump();
 
-                return Ok(Literal(tok.read_hexadec()));
+                return Ok(Literal(tok.read_hexadec(start)));
             },
 
             _ => {}
@@ -1038,50 +1038,6 @@ impl<'a> Tokenizer<'a> {
     }
 
     #[inline]
-    fn read_octal(&mut self) -> Value {
-        let mut value = 0;
-
-        while !self.is_eof() {
-            let peek = self.read_byte();
-            let digit = match peek {
-                b'0'...b'7' => peek - b'0',
-                _           => break
-            };
-
-            value = (value << 3) + digit as u64;
-            self.bump();
-        }
-
-        Value::Number(unsafe {
-            let num = value.to_owned().to_string();
-            OwnedSlice::from_str(&num)
-        })
-    }
-
-    #[inline]
-    fn read_hexadec(&mut self) -> Value {
-        let mut value = 0;
-
-        while !self.is_eof() {
-            let peek = self.read_byte();
-            let digit = match peek {
-                b'0'...b'9' => peek - b'0',
-                b'a'...b'f' => peek - b'a' + 10,
-                b'A'...b'F' => peek - b'A' + 10,
-                _           => break
-            };
-
-            value = (value << 4) + digit as u64;
-            self.bump();
-        }
-
-        Value::Number(unsafe {
-            let num = value.to_owned().to_string();
-            OwnedSlice::from_str(&num)
-        })
-    }
-
-    #[inline]
     fn consume_label_characters(&mut self) -> &str {
         let start = self.index;
 
@@ -1094,6 +1050,33 @@ impl<'a> Tokenizer<'a> {
         unsafe {
             self.source.slice_unchecked(start, self.index)
         }
+    }
+
+    #[inline]
+    fn read_octal(&mut self, start: usize) -> Value {
+
+        while !self.is_eof() {
+            match self.read_byte() {
+                b'0'...b'7' => self.bump(),
+                _           => break
+            };
+        }
+
+        Value::Number(self.slice_source(start, self.index))
+    }
+
+    #[inline]
+    fn read_hexadec(&mut self, start: usize) -> Value {
+        while !self.is_eof() {
+            match self.read_byte() {
+                b'0'...b'9' => self.bump(),
+                b'a'...b'f' => self.bump(),
+                b'A'...b'F' => self.bump(),
+                _           => break
+            };
+        }
+
+        Value::Number(self.slice_source(start, self.index))
     }
 
     #[inline]
@@ -1110,5 +1093,4 @@ impl<'a> Tokenizer<'a> {
 
         Value::Number(value)
     }
-
 }

--- a/core/src/transformer.rs
+++ b/core/src/transformer.rs
@@ -384,6 +384,13 @@ impl Transformable for ObjectMember {
                 return;
             },
 
+            ObjectMember::Value {
+                ref mut key,
+                ref mut value,
+            } => {
+                return;
+            },
+
             ObjectMember::Computed {
                 ref mut key,
                 ref mut value,

--- a/core/src/transformer.rs
+++ b/core/src/transformer.rs
@@ -32,6 +32,13 @@ impl Take for Expression {
     }
 }
 
+impl Take for ObjectKey {
+    #[inline]
+    fn take(&mut self) -> Self {
+        mem::replace(self, ObjectKey::Binary(0))
+    }
+}
+
 #[inline]
 fn bind_this(function: Expression) -> Expression {
     Expression::call(Expression::member(function, "bind"), vec![Expression::This])
@@ -172,8 +179,15 @@ impl Transformable for Expression {
 
                 let mut computed = partition_vec(members, |member| {
                     match member {
-                        &ObjectMember::Computed { .. } => false,
-                        _                              => true,
+                        &ObjectMember::Value {
+                            key: ObjectKey::Computed(_),
+                            ..
+                        } => false,
+                        &ObjectMember::Method {
+                            key: ObjectKey::Computed(_),
+                            ..
+                        } => false,
+                        _ => true,
                     }
                 });
 
@@ -196,8 +210,11 @@ impl Transformable for Expression {
                 });
 
                 for member in computed.drain(..) {
-                    if let ObjectMember::Computed { key, value } = member {
-                        body.push(
+                    body.push(match member {
+                        ObjectMember::Value {
+                            key: ObjectKey::Computed(key),
+                            value,
+                        } => {
                             Expression::binary(
                                 Expression::ComputedMember {
                                     object: Box::new("___".into()),
@@ -206,8 +223,29 @@ impl Transformable for Expression {
                                 Assign,
                                 value
                             ).into()
-                        );
-                    }
+                        }
+
+                        ObjectMember::Method {
+                            key: ObjectKey::Computed(key),
+                            params,
+                            body,
+                        } => {
+                            Expression::binary(
+                                Expression::ComputedMember {
+                                    object: Box::new("___".into()),
+                                    property: Box::new(key),
+                                },
+                                Assign,
+                                Expression::Function {
+                                    name: None,
+                                    params: params,
+                                    body: body
+                                }
+                            ).into()
+                        }
+
+                        _ => unreachable!()
+                    });
                 }
 
                 body.push(Statement::Return {
@@ -358,6 +396,28 @@ impl Transformable for Expression {
     }
 }
 
+impl Transformable for ObjectKey {
+    #[inline]
+    fn transform(&mut self, settings: &Settings) {
+        match *self {
+            ObjectKey::Computed(ref mut expression) => {
+                expression.transform(settings);
+            },
+            _ => {}
+        }
+    }
+
+    #[inline]
+    fn contains_this(&self) -> bool {
+        match *self {
+            ObjectKey::Computed(ref expression) => {
+                expression.contains_this()
+            },
+            _ => false
+        }
+    }
+}
+
 impl Transformable for ObjectMember {
     fn transform(&mut self, settings: &Settings) {
         *self = match *self {
@@ -370,28 +430,13 @@ impl Transformable for ObjectMember {
                     return;
                 }
 
-                ObjectMember::Literal {
-                    key: *key,
+                ObjectMember::Value {
+                    key: ObjectKey::Literal(*key),
                     value: Expression::Identifier(*key),
                 }
             },
 
-            ObjectMember::Literal {
-                ref mut value,
-                ..
-            } => {
-                value.transform(settings);
-                return;
-            },
-
             ObjectMember::Value {
-                ref mut key,
-                ref mut value,
-            } => {
-                return;
-            },
-
-            ObjectMember::Computed {
                 ref mut key,
                 ref mut value,
             } => {
@@ -401,10 +446,11 @@ impl Transformable for ObjectMember {
             },
 
             ObjectMember::Method {
-                ref name,
+                ref mut key,
                 ref mut params,
                 ref mut body,
             } => {
+                key.transform(settings);
                 body.transform(settings);
                 params.transform(settings);
 
@@ -413,31 +459,8 @@ impl Transformable for ObjectMember {
                     return;
                 }
 
-                ObjectMember::Literal {
-                    key: *name,
-                    value: Expression::Function {
-                        name: Some(*name),
-                        params: params.take(),
-                        body: body.take(),
-                    }
-                }
-            },
-
-            ObjectMember::ComputedMethod {
-                ref mut name,
-                ref mut params,
-                ref mut body,
-            } => {
-                body.transform(settings);
-                params.transform(settings);
-
-                // transformation flag check
-                if !settings.transform_object {
-                    return;
-                }
-
-                ObjectMember::Computed {
-                    key: name.take(),
+                ObjectMember::Value {
+                    key: key.take(),
                     value: Expression::Function {
                         name: None,
                         params: params.take(),
@@ -450,12 +473,8 @@ impl Transformable for ObjectMember {
 
     fn contains_this(&self) -> bool {
         match *self {
-            ObjectMember::Literal {
-                ref value,
-                ..
-            } => value.contains_this(),
 
-            ObjectMember::Computed {
+            ObjectMember::Value {
                 ref key,
                 ref value,
             } => key.contains_this() || value.contains_this(),

--- a/core/tests/parser.rs
+++ b/core/tests/parser.rs
@@ -28,6 +28,11 @@ macro_rules! num {
     ($num:expr) => (Expression::Literal(Value::Number($num.into())))
 }
 
+
+macro_rules! expr_bin {
+    ($num:expr) => (Expression::Literal(Value::Binary($num)))
+}
+
 macro_rules! boxnum {
     ($num:expr) => (Box::new(num!($num)))
 }
@@ -255,7 +260,7 @@ fn number_expression() {
 
 #[test]
 fn binary_number_expression() {
-    assert_expression!("0b1100100", num!("100"));
+    assert_expression!("0b1100100", expr_bin!(100u64));
 }
 
 #[test]

--- a/core/tests/parser.rs
+++ b/core/tests/parser.rs
@@ -770,8 +770,8 @@ fn sequence_in_accessor() {
 #[test]
 fn object_string_literal_member() {
     assert_expression!("({foo:100})", Expression::Object(vec![
-        ObjectMember::Literal {
-            key: "foo".into(),
+        ObjectMember::Value {
+            key: ObjectKey::Literal("foo".into()),
             value: num!("100"),
         }
     ]));
@@ -780,8 +780,8 @@ fn object_string_literal_member() {
 #[test]
 fn object_number_literal_member() {
     assert_expression!("({100:100})", Expression::Object(vec![
-        ObjectMember::Literal {
-            key: "100".into(),
+        ObjectMember::Value {
+            key: ObjectKey::Literal("100".into()),
             value: num!("100"),
         }
     ]));
@@ -790,8 +790,8 @@ fn object_number_literal_member() {
 #[test]
 fn object_binary_literal_member() {
     assert_expression!("({ 0b1100100 : 100})", Expression::Object(vec![
-        ObjectMember::Literal {
-            key: "100".into(),
+        ObjectMember::Value {
+            key: ObjectKey::Binary(100),
             value: num!("100"),
         }
     ]));
@@ -800,8 +800,8 @@ fn object_binary_literal_member() {
 #[test]
 fn object_hex_literal_member() {
     assert_expression!("({ 0x64 : 100})", Expression::Object(vec![
-        ObjectMember::Literal {
-            key: "0x64".into(),
+        ObjectMember::Value {
+            key: ObjectKey::Literal("0x64".into()),
             value: num!("100"),
         }
     ]));
@@ -810,8 +810,8 @@ fn object_hex_literal_member() {
 #[test]
 fn object_computed_member() {
     assert_expression!("({[100]:100})", Expression::Object(vec![
-        ObjectMember::Computed {
-            key: num!("100"),
+        ObjectMember::Value {
+            key: ObjectKey::Computed(num!("100")),
             value: num!("100"),
         }
     ]));
@@ -830,7 +830,7 @@ fn object_shorthand_member() {
 fn object_method_member() {
     assert_expression!("({foo() {} })", Expression::Object(vec![
         ObjectMember::Method {
-            name: "foo".into(),
+            key: ObjectKey::Literal("foo".into()),
             params: vec![],
             body: vec![],
         }
@@ -840,8 +840,19 @@ fn object_method_member() {
 #[test]
 fn object_computed_method_member() {
     assert_expression!("({[100]() {} })", Expression::Object(vec![
-        ObjectMember::ComputedMethod {
-            name: num!("100"),
+        ObjectMember::Method {
+            key: ObjectKey::Computed(num!("100")),
+            params: vec![],
+            body: vec![],
+        }
+    ]));
+}
+
+#[test]
+fn object_number_method_member() {
+    assert_expression!("({100 () {} })", Expression::Object(vec![
+        ObjectMember::Method {
+            key: ObjectKey::Literal("100".into()),
             params: vec![],
             body: vec![],
         }

--- a/core/tests/parser.rs
+++ b/core/tests/parser.rs
@@ -265,12 +265,12 @@ fn binary_number_expression() {
 
 #[test]
 fn octal_number_expression() {
-    assert_expression!("0o144", num!("100"));
+    assert_expression!("0o144", num!("0o144"));
 }
 
 #[test]
 fn hexdec_number_expression() {
-    assert_expression!("0x64", num!("100"));
+    assert_expression!("0x64", num!("0x64"));
 }
 
 #[test]
@@ -801,7 +801,7 @@ fn object_binary_literal_member() {
 fn object_hex_literal_member() {
     assert_expression!("({ 0x64 : 100})", Expression::Object(vec![
         ObjectMember::Literal {
-            key: "100".into(),
+            key: "0x64".into(),
             value: num!("100"),
         }
     ]));

--- a/core/tests/parser.rs
+++ b/core/tests/parser.rs
@@ -255,17 +255,17 @@ fn number_expression() {
 
 #[test]
 fn binary_number_expression() {
-    assert_expression!("0b1100100", Expression::Literal(Value::Integer(100)));
+    assert_expression!("0b1100100", num!("100"));
 }
 
 #[test]
 fn octal_number_expression() {
-    assert_expression!("0o144", Expression::Literal(Value::Integer(100)));
+    assert_expression!("0o144", num!("100"));
 }
 
 #[test]
 fn hexdec_number_expression() {
-    assert_expression!("0x64", Expression::Literal(Value::Integer(100)));
+    assert_expression!("0x64", num!("100"));
 }
 
 #[test]
@@ -763,10 +763,40 @@ fn sequence_in_accessor() {
 }
 
 #[test]
-fn object_literal_member() {
+fn object_string_literal_member() {
     assert_expression!("({foo:100})", Expression::Object(vec![
         ObjectMember::Literal {
             key: "foo".into(),
+            value: num!("100"),
+        }
+    ]));
+}
+
+#[test]
+fn object_number_literal_member() {
+    assert_expression!("({100:100})", Expression::Object(vec![
+        ObjectMember::Literal {
+            key: "100".into(),
+            value: num!("100"),
+        }
+    ]));
+}
+
+#[test]
+fn object_binary_literal_member() {
+    assert_expression!("({ 0b1100100 : 100})", Expression::Object(vec![
+        ObjectMember::Literal {
+            key: "100".into(),
+            value: num!("100"),
+        }
+    ]));
+}
+
+#[test]
+fn object_hex_literal_member() {
+    assert_expression!("({ 0x64 : 100})", Expression::Object(vec![
+        ObjectMember::Literal {
+            key: "100".into(),
             value: num!("100"),
         }
     ]));

--- a/core/tests/tokenizer.rs
+++ b/core/tests/tokenizer.rs
@@ -17,7 +17,7 @@ fn test_token(input: &str, expected: Token) -> bool {
     tok == expected
 }
 
-macro_rules! num {
+macro_rules! lit_num {
     ($num:expr) => (Literal(Value::Number($num.into())))
 }
 
@@ -136,12 +136,12 @@ fn test_tokenizer_literals() {
     assert_token!("2", Literal(Value::Number("2".into())), "Value::Number");
 
     assert_token!("0xff", Literal(Value::Number("255".into())), "Value::Number");
-    assert_token!("0xff", num!("255"), "Value::Number");
-    assert_token!("0XFF", num!("255"), "Value::Number");
-    assert_token!("0b01001011", num!("75"), "Value::Number");
-    assert_token!("0B01001011", num!("75"), "Value::Number");
-    assert_token!("0o113", num!("75"), "Value::Number");
-    assert_token!("0O113", num!("75"), "Value::Number");
+    assert_token!("0xff", lit_num!("255"), "Value::Number");
+    assert_token!("0XFF", lit_num!("255"), "Value::Number");
+    assert_token!("0b01001011", lit_num!("75"), "Value::Number");
+    assert_token!("0B01001011", lit_num!("75"), "Value::Number");
+    assert_token!("0o113", lit_num!("75"), "Value::Number");
+    assert_token!("0O113", lit_num!("75"), "Value::Number");
 }
 
 #[test]

--- a/core/tests/tokenizer.rs
+++ b/core/tests/tokenizer.rs
@@ -139,13 +139,13 @@ fn test_tokenizer_literals() {
     assert_token!("2.2", Literal(Value::Number("2.2".into())), "Value::Number");
     assert_token!("2", Literal(Value::Number("2".into())), "Value::Number");
 
-    assert_token!("0xff", Literal(Value::Number("255".into())), "Value::Number");
-    assert_token!("0xff", lit_num!("255"), "Value::Number");
-    assert_token!("0XFF", lit_num!("255"), "Value::Number");
+    assert_token!("0xff", Literal(Value::Number("0xff".into())), "Value::Number");
+    assert_token!("0xff", lit_num!("0xff"), "Value::Number");
+    assert_token!("0XFF", lit_num!("0XFF"), "Value::Number");
     assert_token!("0b01001011", lit_bin!(75u64), "Value::Number");
     assert_token!("0B01001011", lit_bin!(75u64), "Value::Number");
-    assert_token!("0o113", lit_num!("75"), "Value::Number");
-    assert_token!("0O113", lit_num!("75"), "Value::Number");
+    assert_token!("0o113", lit_num!("0o113"), "Value::Number");
+    assert_token!("0O113", lit_num!("0O113"), "Value::Number");
 }
 
 #[test]

--- a/core/tests/tokenizer.rs
+++ b/core/tests/tokenizer.rs
@@ -17,6 +17,10 @@ fn test_token(input: &str, expected: Token) -> bool {
     tok == expected
 }
 
+macro_rules! num {
+    ($num:expr) => (Literal(Value::Number($num.into())))
+}
+
 macro_rules! assert_token {
     ($string:expr, $token:expr, $descr:expr) => {
         assert_eq!(test_token($string, $token), true, $descr);
@@ -131,12 +135,13 @@ fn test_tokenizer_literals() {
     assert_token!("2.2", Literal(Value::Number("2.2".into())), "Value::Number");
     assert_token!("2", Literal(Value::Number("2".into())), "Value::Number");
 
-    assert_token!("0xff", Literal(Value::Integer(255)), "Value::Integer");
-    assert_token!("0XFF", Literal(Value::Integer(255)), "Value::Integer");
-    assert_token!("0b01001011", Literal(Value::Integer(75)), "Value::Integer");
-    assert_token!("0B01001011", Literal(Value::Integer(75)), "Value::Integer");
-    assert_token!("0o113", Literal(Value::Integer(75)), "Value::Integer");
-    assert_token!("0O113", Literal(Value::Integer(75)), "Value::Integer");
+    assert_token!("0xff", Literal(Value::Number("255".into())), "Value::Number");
+    assert_token!("0xff", num!("255"), "Value::Number");
+    assert_token!("0XFF", num!("255"), "Value::Number");
+    assert_token!("0b01001011", num!("75"), "Value::Number");
+    assert_token!("0B01001011", num!("75"), "Value::Number");
+    assert_token!("0o113", num!("75"), "Value::Number");
+    assert_token!("0O113", num!("75"), "Value::Number");
 }
 
 #[test]

--- a/core/tests/tokenizer.rs
+++ b/core/tests/tokenizer.rs
@@ -21,6 +21,10 @@ macro_rules! lit_num {
     ($num:expr) => (Literal(Value::Number($num.into())))
 }
 
+macro_rules! lit_bin {
+    ($num:expr) => (Literal(Value::Binary($num)))
+}
+
 macro_rules! assert_token {
     ($string:expr, $token:expr, $descr:expr) => {
         assert_eq!(test_token($string, $token), true, $descr);
@@ -138,8 +142,8 @@ fn test_tokenizer_literals() {
     assert_token!("0xff", Literal(Value::Number("255".into())), "Value::Number");
     assert_token!("0xff", lit_num!("255"), "Value::Number");
     assert_token!("0XFF", lit_num!("255"), "Value::Number");
-    assert_token!("0b01001011", lit_num!("75"), "Value::Number");
-    assert_token!("0B01001011", lit_num!("75"), "Value::Number");
+    assert_token!("0b01001011", lit_bin!(75u64), "Value::Number");
+    assert_token!("0B01001011", lit_bin!(75u64), "Value::Number");
     assert_token!("0o113", lit_num!("75"), "Value::Number");
     assert_token!("0O113", lit_num!("75"), "Value::Number");
 }


### PR DESCRIPTION
This PR was branched from ``template-string``