### PR TITLE
Correctly balance binary expressions

### DIFF
--- a/ratel-codegen/src/expression.rs
+++ b/ratel-codegen/src/expression.rs
@@ -168,7 +168,10 @@ impl<'ast, G: Generator> ToCode<G> for BinaryExpression<'ast> {
             gen.write_pretty(b' ');
         }
 
-        gen.write_expression(&self.right, bp);
+        // `2 / 2 * 2` and `2 / (2 * 2)` are different expressions,
+        // hence the need for parenthesis in a right-balanced tree
+        // even if binding power of operators is exactly the same.
+        gen.write_expression(&self.right, bp + 1);
     }
 }
 
@@ -488,5 +491,8 @@ mod test {
         assert_min("(1 + 2) * 3;", "(1+2)*3;");
         assert_min("(denominator / divider * 100).toFixed(2);", "(denominator/divider*100).toFixed(2);");
         assert_min("(1 + 1)[0];", "(1+1)[0];");
+        assert_min("2 * 2 / 2;", "2*2/2;");
+        assert_min("2 * (2 / 2);", "2*(2/2);");
+        assert_min("(2 * 2) / 2;", "2*2/2;");
     }
 }

--- a/ratel/src/parser/function.rs
+++ b/ratel/src/parser/function.rs
@@ -1,5 +1,5 @@
 use toolshed::list::ListBuilder;
-use parser::{Parser, Parse, B0, B1};
+use parser::{Parser, Parse, ANY, B0};
 use lexer::Token::*;
 use ast::{Node, NodeList, EmptyName, OptionalName, MandatoryName, Name};
 use ast::{MethodKind, Pattern, Function, Class, ClassMember, PropertyKey};
@@ -139,7 +139,7 @@ impl<'ast> Parse<'ast> for ClassMember<'ast> {
             BracketOpen => {
                 par.lexer.consume();
 
-                let expression = par.expression::<B0>();
+                let expression = par.expression::<ANY>();
 
                 expect!(par, BracketClose);
 
@@ -165,7 +165,7 @@ impl<'ast> Parse<'ast> for ClassMember<'ast> {
             OperatorAssign => {
                 par.lexer.consume();
 
-                let expression = par.expression::<B1>();
+                let expression = par.expression::<B0>();
 
                 end = expression.end;
 
@@ -199,7 +199,7 @@ impl<'ast, N> Parse<'ast> for Class<'ast, N> where
             Extends => {
                 par.lexer.consume();
 
-                Some(par.expression::<B1>())
+                Some(par.expression::<B0>())
             },
             _ => None
         };
@@ -257,7 +257,7 @@ impl<'ast> Parser<'ast> {
             OperatorAssign => {
                 self.lexer.consume();
 
-                let right = self.expression::<B1>();
+                let right = self.expression::<B0>();
 
                 self.alloc_at_loc(left.start, right.end, Pattern::AssignmentPattern {
                     left,

--- a/ratel/src/parser/nested.rs
+++ b/ratel/src/parser/nested.rs
@@ -31,7 +31,7 @@ macro_rules! bp {
 }
 
 /// All potential tokens, including Comma for sequence expressions
-bp!(B0, [
+bp!(ANY, [
     ____, ____, ____, SEQ,  CALL, ____, CMEM, ____, ____, ____, ARRW, ____,
 //  EOF   ;     :     ,     (     )     [     ]     {     }     =>    NEW
 
@@ -60,7 +60,7 @@ bp!(B0, [
 //  IMPL  PCKG  PROT  IFACE PRIV  PUBLI IDENT ACCSS TPL_O TPL_C ERR_T ERR_E
 ]);
 
-bp!(B1, [
+bp!(B0, [
     ____, ____, ____, ____, CALL, ____, CMEM, ____, ____, ____, ARRW, ____,
     INC,  DEC,  ____, ____, ____, ____, ____, MUL,  DIV,  REM,  EXPN, ADD,
     SUB,  BSL,  BSR,  UBSR, LESS, LSEQ, GRTR, GREQ, INOF, IN,   STEQ, SIEQ,
@@ -72,7 +72,7 @@ bp!(B1, [
     ____, ____, ____, ____, ____, ____, ____, ACCS, TPLE, TPLS, ____, ____,
 ]);
 
-bp!(B4, [
+bp!(B1, [
     ____, ____, ____, ____, CALL, ____, CMEM, ____, ____, ____, ARRW, ____,
     INC,  DEC,  ____, ____, ____, ____, ____, MUL,  DIV,  REM,  EXPN, ADD,
     SUB,  BSL,  BSR,  UBSR, LESS, LSEQ, GRTR, GREQ, INOF, IN,   STEQ, SIEQ,
@@ -84,7 +84,7 @@ bp!(B4, [
     ____, ____, ____, ____, ____, ____, ____, ACCS, TPLE, TPLS, ____, ____,
 ]);
 
-bp!(B5, [
+bp!(B4, [
     ____, ____, ____, ____, CALL, ____, CMEM, ____, ____, ____, ARRW, ____,
     INC,  DEC,  ____, ____, ____, ____, ____, MUL,  DIV,  REM,  EXPN, ADD,
     SUB,  BSL,  BSR,  UBSR, LESS, LSEQ, GRTR, GREQ, INOF, IN,   STEQ, SIEQ,
@@ -96,7 +96,7 @@ bp!(B5, [
     ____, ____, ____, ____, ____, ____, ____, ACCS, TPLE, TPLS, ____, ____,
 ]);
 
-bp!(B6, [
+bp!(B5, [
     ____, ____, ____, ____, CALL, ____, CMEM, ____, ____, ____, ARRW, ____,
     INC,  DEC,  ____, ____, ____, ____, ____, MUL,  DIV,  REM,  EXPN, ADD,
     SUB,  BSL,  BSR,  UBSR, LESS, LSEQ, GRTR, GREQ, INOF, IN,   STEQ, SIEQ,
@@ -108,7 +108,7 @@ bp!(B6, [
     ____, ____, ____, ____, ____, ____, ____, ACCS, TPLE, TPLS, ____, ____,
 ]);
 
-bp!(B7, [
+bp!(B6, [
     ____, ____, ____, ____, CALL, ____, CMEM, ____, ____, ____, ARRW, ____,
     INC,  DEC,  ____, ____, ____, ____, ____, MUL,  DIV,  REM,  EXPN, ADD,
     SUB,  BSL,  BSR,  UBSR, LESS, LSEQ, GRTR, GREQ, INOF, IN,   STEQ, SIEQ,
@@ -120,7 +120,7 @@ bp!(B7, [
     ____, ____, ____, ____, ____, ____, ____, ACCS, TPLE, TPLS, ____, ____,
 ]);
 
-bp!(B8, [
+bp!(B7, [
     ____, ____, ____, ____, CALL, ____, CMEM, ____, ____, ____, ARRW, ____,
     INC,  DEC,  ____, ____, ____, ____, ____, MUL,  DIV,  REM,  EXPN, ADD,
     SUB,  BSL,  BSR,  UBSR, LESS, LSEQ, GRTR, GREQ, INOF, IN,   STEQ, SIEQ,
@@ -132,7 +132,7 @@ bp!(B8, [
     ____, ____, ____, ____, ____, ____, ____, ACCS, TPLE, TPLS, ____, ____,
 ]);
 
-bp!(B9, [
+bp!(B8, [
     ____, ____, ____, ____, CALL, ____, CMEM, ____, ____, ____, ARRW, ____,
     INC,  DEC,  ____, ____, ____, ____, ____, MUL,  DIV,  REM,  EXPN, ADD,
     SUB,  BSL,  BSR,  UBSR, LESS, LSEQ, GRTR, GREQ, INOF, IN,   STEQ, SIEQ,
@@ -144,7 +144,7 @@ bp!(B9, [
     ____, ____, ____, ____, ____, ____, ____, ACCS, TPLE, TPLS, ____, ____,
 ]);
 
-bp!(B10, [
+bp!(B9, [
     ____, ____, ____, ____, CALL, ____, CMEM, ____, ____, ____, ARRW, ____,
     INC,  DEC,  ____, ____, ____, ____, ____, MUL,  DIV,  REM,  EXPN, ADD,
     SUB,  BSL,  BSR,  UBSR, LESS, LSEQ, GRTR, GREQ, INOF, IN,   STEQ, SIEQ,
@@ -156,7 +156,7 @@ bp!(B10, [
     ____, ____, ____, ____, ____, ____, ____, ACCS, TPLE, TPLS, ____, ____,
 ]);
 
-bp!(B11, [
+bp!(B10, [
     ____, ____, ____, ____, CALL, ____, CMEM, ____, ____, ____, ARRW, ____,
     INC,  DEC,  ____, ____, ____, ____, ____, MUL,  DIV,  REM,  EXPN, ADD,
     SUB,  BSL,  BSR,  UBSR, LESS, LSEQ, GRTR, GREQ, INOF, IN,   ____, ____,
@@ -168,7 +168,7 @@ bp!(B11, [
     ____, ____, ____, ____, ____, ____, ____, ACCS, TPLE, TPLS, ____, ____,
 ]);
 
-bp!(B12, [
+bp!(B11, [
     ____, ____, ____, ____, CALL, ____, CMEM, ____, ____, ____, ARRW, ____,
     INC,  DEC,  ____, ____, ____, ____, ____, MUL,  DIV,  REM,  EXPN, ADD,
     SUB,  BSL,  BSR,  UBSR, ____, ____, ____, ____, ____, ____, ____, ____,
@@ -180,7 +180,7 @@ bp!(B12, [
     ____, ____, ____, ____, ____, ____, ____, ACCS, TPLE, TPLS, ____, ____,
 ]);
 
-bp!(B13, [
+bp!(B12, [
     ____, ____, ____, ____, CALL, ____, CMEM, ____, ____, ____, ARRW, ____,
     INC,  DEC,  ____, ____, ____, ____, ____, MUL,  DIV,  REM,  EXPN, ADD,
     SUB,  ____, ____, ____, ____, ____, ____, ____, ____, ____, ____, ____,
@@ -192,7 +192,7 @@ bp!(B13, [
     ____, ____, ____, ____, ____, ____, ____, ACCS, TPLE, TPLS, ____, ____,
 ]);
 
-bp!(B14, [
+bp!(B13, [
     ____, ____, ____, ____, CALL, ____, CMEM, ____, ____, ____, ARRW, ____,
     INC,  DEC,  ____, ____, ____, ____, ____, MUL,  DIV,  REM,  EXPN, ____,
     ____, ____, ____, ____, ____, ____, ____, ____, ____, ____, ____, ____,
@@ -204,9 +204,21 @@ bp!(B14, [
     ____, ____, ____, ____, ____, ____, ____, ACCS, TPLE, TPLS, ____, ____,
 ]);
 
-bp!(B15, [
+bp!(B14, [
     ____, ____, ____, ____, CALL, ____, CMEM, ____, ____, ____, ARRW, ____,
     INC,  DEC,  ____, ____, ____, ____, ____, ____, ____, ____, EXPN, ____,
+    ____, ____, ____, ____, ____, ____, ____, ____, ____, ____, ____, ____,
+    ____, ____, ____, ____, ____, ____, ____, ____, ____, ____, ____, ____,
+    ____, ____, ____, ____, ____, ____, ____, ____, ____, ____, ____, ____,
+    ____, ____, ____, ____, ____, ____, ____, ____, ____, ____, ____, ____,
+    ____, ____, ____, ____, ____, ____, ____, ____, ____, ____, ____, ____,
+    ____, ____, ____, ____, ____, ____, ____, ____, ____, ____, ____, ____,
+    ____, ____, ____, ____, ____, ____, ____, ACCS, TPLE, TPLS, ____, ____,
+]);
+
+bp!(B15, [
+    ____, ____, ____, ____, CALL, ____, CMEM, ____, ____, ____, ARRW, ____,
+    INC,  DEC,  ____, ____, ____, ____, ____, ____, ____, ____, ____, ____,
     ____, ____, ____, ____, ____, ____, ____, ____, ____, ____, ____, ____,
     ____, ____, ____, ____, ____, ____, ____, ____, ____, ____, ____, ____,
     ____, ____, ____, ____, ____, ____, ____, ____, ____, ____, ____, ____,
@@ -222,11 +234,11 @@ const SEQ: NestedHandler = Some(|par, left| {
     par.lexer.consume();
 
     let builder = ListBuilder::new(par.arena, left);
-    builder.push(par.arena, par.expression::<B1>());
+    builder.push(par.arena, par.expression::<B0>());
 
     while let Comma = par.lexer.token {
         par.lexer.consume();
-        builder.push(par.arena, par.expression::<B1>());
+        builder.push(par.arena, par.expression::<B0>());
     }
 
     par.alloc_at_loc(0, 0, SequenceExpression {
@@ -305,7 +317,7 @@ const CALL: NestedHandler = Some(|par, left| {
 const CMEM: NestedHandler = Some(|par, left| {
     par.lexer.consume();
 
-    let property = par.expression::<B0>();
+    let property = par.expression::<ANY>();
 
     expect!(par, BracketClose);
 

--- a/ratel/src/parser/statement.rs
+++ b/ratel/src/parser/statement.rs
@@ -1,5 +1,5 @@
 use toolshed::list::{ListBuilder, GrowableList};
-use parser::{Parser, Parse, B0, B1};
+use parser::{Parser, Parse, ANY, B0};
 use lexer::Token::*;
 use lexer::Asi;
 use ast::{Node, NodeList, Declarator, DeclarationKind};
@@ -110,7 +110,7 @@ impl<'ast> Parse<'ast> for SwitchCase<'ast> {
             Case => {
                 par.lexer.consume();
 
-                Some(par.expression::<B0>())
+                Some(par.expression::<ANY>())
             },
             Default => {
                 par.lexer.consume();
@@ -175,7 +175,7 @@ impl<'ast> Parser<'ast> {
 
     #[inline]
     pub fn expression_statement(&mut self, expression: ExpressionNode<'ast>) -> StatementNode<'ast> {
-        let expression = self.nested_expression::<B0>(expression);
+        let expression = self.nested_expression::<ANY>(expression);
 
         self.wrap_expression(expression)
     }
@@ -205,7 +205,7 @@ impl<'ast> Parser<'ast> {
         }
 
         let expression = self.alloc_at_loc(start, end, label);
-        let expression = self.nested_expression::<B0>(expression);
+        let expression = self.nested_expression::<ANY>(expression);
 
         self.expect_semicolon();
 
@@ -250,7 +250,7 @@ impl<'ast> Parser<'ast> {
         let (init, end) = match self.lexer.token {
             OperatorAssign => {
                 self.lexer.consume();
-                let init = self.expression::<B1>();
+                let init = self.expression::<B0>();
 
                 (Some(init), init.end)
             },
@@ -289,7 +289,7 @@ impl<'ast> Parser<'ast> {
 
         let value = match self.asi() {
             Asi::NoSemicolon => {
-                let expression = self.expression::<B0>();
+                let expression = self.expression::<ANY>();
                 end = expression.end;
 
                 self.expect_semicolon();
@@ -359,7 +359,7 @@ impl<'ast> Parser<'ast> {
     #[inline]
     pub fn throw_statement(&mut self) -> StatementNode<'ast> {
         let start = self.lexer.start_then_consume();
-        let value = self.expression::<B0>();
+        let value = self.expression::<ANY>();
 
         self.expect_semicolon();
 
@@ -418,7 +418,7 @@ impl<'ast> Parser<'ast> {
     pub fn if_statement(&mut self) -> StatementNode<'ast> {
         let start = self.lexer.start_then_consume();
         expect!(self, ParenOpen);
-        let test = self.expression::<B0>();
+        let test = self.expression::<ANY>();
         expect!(self, ParenClose);
 
         let consequent = self.statement();
@@ -443,7 +443,7 @@ impl<'ast> Parser<'ast> {
     pub fn while_statement(&mut self) -> StatementNode<'ast> {
         let start = self.lexer.start_then_consume();
         expect!(self, ParenOpen);
-        let test = self.expression::<B0>();
+        let test = self.expression::<ANY>();
         expect!(self, ParenClose);
 
         let body = self.statement();
@@ -460,7 +460,7 @@ impl<'ast> Parser<'ast> {
         let body = self.statement();
         expect!(self, While);
         expect!(self, ParenOpen);
-        let test = self.expression::<B0>();
+        let test = self.expression::<ANY>();
         let end = self.lexer.end();
         expect!(self, ParenClose);
 
@@ -497,7 +497,7 @@ impl<'ast> Parser<'ast> {
             DeclarationLet   => Some(self.for_init(DeclarationKind::Let)),
             DeclarationConst => Some(self.for_init(DeclarationKind::Const)),
             _ => {
-                let init = self.expression::<B0>();
+                let init = self.expression::<ANY>();
 
                 if let Expression::Binary(BinaryExpression {
                     operator: In,
@@ -534,7 +534,7 @@ impl<'ast> Parser<'ast> {
                 None
             },
             _ => {
-                let test = self.expression::<B0>();
+                let test = self.expression::<ANY>();
                 expect!(self, Semicolon);
 
                 Some(test)
@@ -547,7 +547,7 @@ impl<'ast> Parser<'ast> {
                 None
             },
             _         => {
-                let update = self.expression::<B0>();
+                let update = self.expression::<ANY>();
                 expect!(self, ParenClose);
 
                 Some(update)
@@ -577,7 +577,7 @@ impl<'ast> Parser<'ast> {
     }
 
     fn for_in_statement(&mut self, start: u32, left: Node<'ast, ForInit<'ast>>) -> StatementNode<'ast> {
-        let right = self.expression::<B0>();
+        let right = self.expression::<ANY>();
 
         expect!(self, ParenClose);
 
@@ -591,7 +591,7 @@ impl<'ast> Parser<'ast> {
     }
 
     fn for_of_statement(&mut self, start: u32, left: Node<'ast, ForInit<'ast>>) -> StatementNode<'ast> {
-        let right = self.expression::<B0>();
+        let right = self.expression::<ANY>();
 
         expect!(self, ParenClose);
 
@@ -608,7 +608,7 @@ impl<'ast> Parser<'ast> {
         let start = self.lexer.start_then_consume();
         expect!(self, ParenOpen);
 
-        let discriminant = self.expression::<B0>();
+        let discriminant = self.expression::<ANY>();
 
         expect!(self, ParenClose);
 


### PR DESCRIPTION
More tests and stuff.

Nested binary expressions with operators that have the same precedence like `a * b / c` should be left heavy (represented in the tree as `((a * b) / c)`) where previously they were right heavy (`(a * (b / c))`).