### PR TITLE
fix parse function call expression, block comment and impl void expression serializing

### DIFF
--- a/ratel-transformer/src/es2015/arrow.rs
+++ b/ratel-transformer/src/es2015/arrow.rs
@@ -26,6 +26,7 @@ impl<'ast> StaticVisitor<'ast> for TransformArrow {
 
         t.swap(ptr, Function {
             name: OptionalName::empty(),
+            generator: false,
             params: node.params,
             body,
         });

--- a/ratel/src/ast/function.rs
+++ b/ratel/src/ast/function.rs
@@ -65,6 +65,7 @@ impl<'ast> From<Option<IdentifierNode<'ast>>> for OptionalName<'ast> {
 #[derive(Debug, PartialEq, Clone, Copy)]
 pub struct Function<'ast, N: Name<'ast>> {
     pub name: N,
+    pub generator: bool,
     pub params: PatternList<'ast>,
     pub body: BlockNode<'ast, Statement<'ast>>,
 }

--- a/ratel/src/astgen/expression.rs
+++ b/ratel/src/astgen/expression.rs
@@ -886,6 +886,7 @@ mod test {
                                         "computed": false,
                                         "value": {
                                             "type": "FunctionExpression",
+                                            "generator": false,
                                             "id": null,
                                             "params": [
                                                 {
@@ -1000,6 +1001,7 @@ mod test {
             "body": [
                 {
                     "type": "FunctionDeclaration",
+                    "generator": false,
                     "id": {
                         "type": "Identifier",
                         "name": "foo",
@@ -1249,6 +1251,7 @@ mod test {
             "body": [
                 {
                     "type": "FunctionDeclaration",
+                    "generator": false,
                     "id": {
                         "type": "Identifier",
                         "name": "foo",
@@ -1275,6 +1278,7 @@ mod test {
             "body": [
                 {
                     "type": "FunctionDeclaration",
+                    "generator": false,
                     "id": {
                         "type": "Identifier",
                         "name": "foo",
@@ -1410,6 +1414,7 @@ mod test {
                             },
                             "value": {
                                 "type": "FunctionExpression",
+                                "generator": false,
                                 "id": null,
                                 "params": [],
                                 "body": {
@@ -1465,6 +1470,7 @@ mod test {
                             },
                             "value": {
                                 "type": "FunctionExpression",
+                                "generator": false,
                                 "id": null,
                                 "params": [],
                                 "body": {

--- a/ratel/src/astgen/function.rs
+++ b/ratel/src/astgen/function.rs
@@ -122,6 +122,7 @@ where
         S: Serializer,
     {
         self.in_loc(serializer, N::IN_FUNCTION, 3, |state| {
+            state.serialize_field("generator", &self.generator)?;
             state.serialize_field("id", &self.name)?;
             state.serialize_field("params", &self.params)?;
             state.serialize_field("body", &self.body)

--- a/ratel/src/astgen/statement.rs
+++ b/ratel/src/astgen/statement.rs
@@ -946,6 +946,7 @@ mod test {
             "body": [
                 {
                     "type": "FunctionDeclaration",
+                    "generator": false,
                     "id": {
                         "type": "Identifier",
                         "name": "foo",
@@ -967,11 +968,39 @@ mod test {
             "end": 18,
         });
 
+        expect_parse!("function* foo () {}", {
+            "type": "Program",
+            "body": [
+                {
+                    "type": "FunctionDeclaration",
+                    "generator": true,
+                    "id": {
+                        "type": "Identifier",
+                        "name": "foo",
+                        "start": 10,
+                        "end": 13
+                    },
+                    "params": [],
+                    "body": {
+                        "type": "BlockStatement",
+                        "body": [],
+                        "start": 17,
+                        "end": 19,
+                    },
+                    "start": 0,
+                    "end": 19,
+                }
+            ],
+            "start": 0,
+            "end": 19,
+        });
+
         expect_parse!("function foo (a, value = true) {}", {
             "type": "Program",
             "body": [
                 {
                     "type": "FunctionDeclaration",
+                    "generator": false,
                     "id": {
                         "type": "Identifier",
                         "name": "foo",

--- a/ratel/src/lexer/mod.rs
+++ b/ratel/src/lexer/mod.rs
@@ -412,9 +412,10 @@ const SLH: ByteHandler = Some(|lex| {
 
         // block comment
         b'*' => {
+            lex.bump();
             // Keep consuming bytes until */ happens in a row
             unwind_loop!({
-                match lex.next_byte() {
+                match lex.read_byte() {
                     b'*' => {
                         match lex.next_byte() {
                             b'/' => {
@@ -426,7 +427,7 @@ const SLH: ByteHandler = Some(|lex| {
                         }
                     },
                     0 => return lex.token = UnexpectedEndOfProgram,
-                    _ => {}
+                    _ => lex.bump()
                 }
             });
         },
@@ -1063,6 +1064,8 @@ mod test {
     #[test]
     fn block_comment() {
         assert_lex(" /* foo */ bar", [(Identifier, "bar")]);
+        assert_lex(" /** foo **/ bar", [(Identifier, "bar")]);
+        assert_lex(" /*abc foo **/ bar", [(Identifier, "bar")]);
     }
 
     #[test]

--- a/ratel/src/parser/expression.rs
+++ b/ratel/src/parser/expression.rs
@@ -277,6 +277,11 @@ impl<'ast> Parser<'ast> {
                 ParenClose => break,
                 Comma      => {
                     self.lexer.consume();
+
+                    if self.lexer.token == ParenClose {
+                        break
+                    }
+                    
                     self.expression_in_context::<B0>(CALL_CONTEXT)
                 }
                 _ => {
@@ -747,15 +752,75 @@ mod test {
 
     #[test]
     fn call_expression() {
-        let src = "foo();";
-        let mock = Mock::new();
+        {
+            let src = "foo();";
+            let mock = Mock::new();
 
-        let expected = CallExpression {
-            callee: mock.ptr("foo"),
-            arguments: NodeList::empty(),
-        };
+            let expected = CallExpression {
+                callee: mock.ptr("foo"),
+                arguments: NodeList::empty(),
+            };
 
-        assert_expr!(src, expected);
+            assert_expr!(src, expected);
+        }
+        
+        {
+            let src = "foo(1);";
+            let mock = Mock::new();
+
+            let expected = CallExpression {
+                callee: mock.ptr("foo"),
+                arguments: mock.list([
+                    Literal::Number("1"),
+                ]),
+            };
+
+            assert_expr!(src, expected);
+        }
+
+        {
+            let src = "foo(1,2);";
+            let mock = Mock::new();
+
+            let expected = CallExpression {
+                callee: mock.ptr("foo"),
+                arguments: mock.list([
+                    Literal::Number("1"),
+                    Literal::Number("2"),
+                ]),
+            };
+
+            assert_expr!(src, expected);
+        }
+
+        {
+            let src = "foo(1,);";
+            let mock = Mock::new();
+
+            let expected = CallExpression {
+                callee: mock.ptr("foo"),
+                arguments: mock.list([
+                    Literal::Number("1"),
+                ]),
+            };
+
+            assert_expr!(src, expected);
+        }
+
+        {
+            let src = "foo(1,2,);";
+            let mock = Mock::new();
+
+            let expected = CallExpression {
+                callee: mock.ptr("foo"),
+                arguments: mock.list([
+                    Literal::Number("1"),
+                    Literal::Number("2"),
+                ]),
+            };
+
+            assert_expr!(src, expected);
+        }
     }
 
     #[test]

--- a/ratel/src/parser/expression.rs
+++ b/ratel/src/parser/expression.rs
@@ -956,6 +956,7 @@ mod test {
 
         let expected = Function {
             name: None.into(),
+            generator: false,
             params: NodeList::empty(),
             body: mock.empty_block()
         };
@@ -970,6 +971,7 @@ mod test {
 
         let expected = Function {
             name: mock.name("foo"),
+            generator: false,
             params: NodeList::empty(),
             body: mock.empty_block()
         };

--- a/ratel/src/parser/function.rs
+++ b/ratel/src/parser/function.rs
@@ -66,10 +66,18 @@ impl<'ast, N> Parse<'ast> for Function<'ast, N> where
 
     #[inline]
     fn parse(par: &mut Parser<'ast>) -> Self::Output {
+        let generator: bool = if par.lexer.token == OperatorMultiplication {
+            par.lexer.consume();
+            true
+        } else {
+            false
+        };
+
         let name = N::parse(par);
 
         Function {
             name,
+            generator,
             params: par.params(),
             body: par.block(),
         }
@@ -386,12 +394,64 @@ mod test {
         let expected = mock.list([
             Function {
                 name: mock.name("foo"),
+                generator: false,
                 params: NodeList::empty(),
                 body: mock.empty_block(),
             }
         ]);
 
         assert_eq!(parse(src).unwrap().body(), expected);
+    }
+
+    #[test]
+    fn function_with_generator_flag() {
+        {
+            let src = "function* foo() {}";
+            let mock = Mock::new();
+
+            let expected = mock.list([
+                Function {
+                    name: mock.name("foo"),
+                    generator: true,
+                    params: NodeList::empty(),
+                    body: mock.empty_block(),
+                }
+            ]);
+
+            assert_eq!(parse(src).unwrap().body(), expected);
+        }
+        
+        {
+            let src = "function * foo() {}";
+            let mock = Mock::new();
+
+            let expected = mock.list([
+                Function {
+                    name: mock.name("foo"),
+                    generator: true,
+                    params: NodeList::empty(),
+                    body: mock.empty_block(),
+                }
+            ]);
+
+            assert_eq!(parse(src).unwrap().body(), expected);
+        }
+
+        {
+            let src = "function *foo() {}";
+            let mock = Mock::new();
+
+            let expected = mock.list([
+                Function {
+                    name: mock.name("foo"),
+                    generator: true,
+                    params: NodeList::empty(),
+                    body: mock.empty_block(),
+                }
+            ]);
+
+            assert_eq!(parse(src).unwrap().body(), expected);
+        }
     }
 
     #[test]
@@ -402,6 +462,7 @@ mod test {
         let expected = mock.list([
             Function {
                 name: mock.name("foo"),
+                generator: false,
                 params: mock.list([
                     Pattern::Identifier("bar"),
                     Pattern::Identifier("baz"),
@@ -421,6 +482,7 @@ mod test {
         let expected = mock.list([
             Function {
                 name: mock.name("foo"),
+                generator: false,
                 params: NodeList::empty(),
                 body: mock.block([
                     mock.ptr("bar"),
@@ -440,6 +502,7 @@ mod test {
         let expected = mock.list([
             Function {
                 name: mock.name("foo"),
+                generator: false,
                 params: mock.list([
                     Pattern::AssignmentPattern {
                         left: mock.ptr(Pattern::Identifier("a")),
@@ -472,6 +535,7 @@ mod test {
         let expected = mock.list([
             Function {
                 name: mock.name("foo"),
+                generator: false,
                 params: mock.list([
                     Pattern::Identifier("a"),
                     Pattern::Identifier("b"),
@@ -499,6 +563,7 @@ mod test {
         let expected = mock.list([
             Function {
                 name: mock.name("foo"),
+                generator: false,
                 params: mock.list([
                     Pattern::RestElement {
                         argument: mock.ptr("rest"),
@@ -518,6 +583,7 @@ mod test {
         let expected = mock.list([
             Function {
                 name: mock.name("foo"),
+                generator: false,
                 params: mock.list([
                     Pattern::Identifier("a"),
                     Pattern::AssignmentPattern {
@@ -595,6 +661,7 @@ mod test {
                         kind: MethodKind::Constructor,
                         value: mock.ptr(Function {
                             name: EmptyName,
+                            generator: false,
                             params: mock.list([
                                 Pattern::Identifier("bar"),
                                 Pattern::Identifier("baz")
@@ -643,6 +710,7 @@ mod test {
                         kind: MethodKind::Method,
                         value: mock.ptr(Function {
                             name: EmptyName,
+                            generator: false,
                             params: mock.list([
                                 Pattern::Identifier("bar"),
                                 Pattern::Identifier("baz")
@@ -658,6 +726,7 @@ mod test {
                         kind: MethodKind::Method,
                         value: mock.ptr(Function {
                             name: EmptyName,
+                            generator: false,
                             params: mock.list([
                                 Pattern::Identifier("moon")
                             ]),
@@ -672,6 +741,7 @@ mod test {
                         kind: MethodKind::Method,
                         value: mock.ptr(Function {
                             name: EmptyName,
+                            generator: false,
                             params: NodeList::empty(),
                             body: mock.empty_block()
                         })
@@ -682,6 +752,7 @@ mod test {
                         kind: MethodKind::Method,
                         value: mock.ptr(Function {
                             name: EmptyName,
+                            generator: false,
                             params: NodeList::empty(),
                             body: mock.empty_block()
                         })
@@ -692,6 +763,7 @@ mod test {
                         kind: MethodKind::Method,
                         value: mock.ptr(Function {
                             name: EmptyName,
+                            generator: false,
                             params: NodeList::empty(),
                             body: mock.empty_block()
                         })
@@ -789,6 +861,7 @@ mod test {
                         kind: MethodKind::Get,
                         value: mock.ptr(Function {
                             name: EmptyName,
+                            generator: false,
                             params: mock.list([
                                 Pattern::Identifier("foo")
                             ]),
@@ -801,6 +874,7 @@ mod test {
                         kind: MethodKind::Set,
                         value: mock.ptr(Function {
                             name: EmptyName,
+                            generator: false,
                             params: mock.list([
                                 Pattern::Identifier("bar")
                             ]),

--- a/ratel/src/parser/statement.rs
+++ b/ratel/src/parser/statement.rs
@@ -1132,6 +1132,7 @@ mod test {
         let expected = mock.list([
             Function {
                 name: mock.name("foo"),
+                generator: false,
                 params: NodeList::empty(),
                 body: mock.empty_block(),
             }


### PR DESCRIPTION
1. fix parse block comment
2. fix parse function call expression
3. impl void expression serializing

4. impl parse generator function ( issue: #14  )
