### PR TITLE
Compatible with Firefox Nightly

### DIFF
--- a/ratel-wasm/client-src/client.js
+++ b/ratel-wasm/client-src/client.js
@@ -71,7 +71,7 @@
       } else if (mode === 2) {
         output = generateASTEstree(value, minify);
       }
-      ast_output.innerHTML = output;
+      ast_output.textContent = output;
     }, immediate ? 0 : DISPLAY_TIMEOUT);
   }
 
@@ -80,7 +80,7 @@
       try {
         onInput(e.target.value);
       } catch (e) {
-        ast_output.innerText = e.message || e;
+        ast_output.textContent = e.message || e;
       }
     };
 


### PR DESCRIPTION
In firefox browser, `innerText` method will auto replace `\n` to `<br />` .

<img width="1015" alt="image" src="https://user-images.githubusercontent.com/717717/41463464-25e832aa-70c9-11e8-837b-7eb109054d21.png">
