### PR TITLE
Correcting ASI, adding Expression: `is_lvalue`, replacing `OperatorKind::is_word` with `OperatorKind::category`

### DIFF
--- a/ratel/src/ast/expression.rs
+++ b/ratel/src/ast/expression.rs
@@ -222,13 +222,12 @@ impl<'ast> Expression<'ast> {
         use self::Expression::*;
 
         match *self {
-            Expression::Identifier(_) |
-            Expression::Member(_)     |
-            Expression::Object(_)     |
-            Expression::Array(_)      |
-            Expression::Spread(_)     => true,
-            _                         => false
+            Identifier(_) |
+            Member(_)     |
+            Object(_)     |
+            Array(_)      |
+            Spread(_)     => true,
+            _             => false
         }
     }
-
 }

--- a/ratel/src/ast/expression.rs
+++ b/ratel/src/ast/expression.rs
@@ -216,4 +216,19 @@ impl<'ast> Expression<'ast> {
             _           => true,
         }
     }
+
+    #[inline]
+    pub fn is_lvalue(&self) -> bool {
+        use self::Expression::*;
+
+        match *self {
+            Expression::Identifier(_) |
+            Expression::Member(_)     |
+            Expression::Object(_)     |
+            Expression::Array(_)      |
+            Expression::Spread(_)     => true,
+            _                         => false
+        }
+    }
+
 }

--- a/ratel/src/ast/operator.rs
+++ b/ratel/src/ast/operator.rs
@@ -53,6 +53,15 @@ pub enum OperatorKind {
     Spread,           //     ... …
 }
 
+
+#[derive(Debug, PartialEq, Clone)]
+pub enum OperatorCategory {
+    Minus,
+    Plus,
+    Safe,
+    Word,
+}
+
 use self::OperatorKind::*;
 
 impl OperatorKind {
@@ -320,16 +329,22 @@ impl OperatorKind {
     }
 
     #[inline]
-    pub fn is_word(&self) -> bool {
-        match *self {
-            In         |
-            New        |
-            Typeof     |
-            Void       |
-            Delete     |
-            Instanceof => true,
+    pub fn category(&self) -> OperatorCategory {
+        use self::Token::*;
 
-            _          => false,
+        match *self {
+            In            |
+            New           |
+            Typeof        |
+            Void          |
+            Delete        |
+            Instanceof    => OperatorCategory::Word,
+            Addition      |
+            Increment     => OperatorCategory::Plus,
+            Subtraction   |
+            Decrement     => OperatorCategory::Minus,
+
+            _             => OperatorCategory::Safe,
         }
     }
 }

--- a/ratel/src/ast/operator.rs
+++ b/ratel/src/ast/operator.rs
@@ -330,8 +330,6 @@ impl OperatorKind {
 
     #[inline]
     pub fn category(&self) -> OperatorCategory {
-        use self::Token::*;
-
         match *self {
             In            |
             New           |

--- a/ratel/src/lexer/mod.rs
+++ b/ratel/src/lexer/mod.rs
@@ -39,7 +39,7 @@ macro_rules! unwind_loop {
 }
 
 /// Contextual check describing which Automatic Semicolon Insertion rules can be applied.
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, PartialEq)]
 pub enum Asi {
     /// Current token is a semicolon. Parser should consume it and finalize the statement.
     ExplicitSemicolon,

--- a/ratel/src/parser/expression.rs
+++ b/ratel/src/parser/expression.rs
@@ -1267,4 +1267,18 @@ mod test {
         ]);
         assert_eq!(parse(src).unwrap().body(), expected);
     }
+
+    #[test]
+    fn regression_asi_safe() {
+        let src = r#"foo
+        .bar"#;
+        let mock = Mock::new();
+
+        let expected = MemberExpression {
+            object: mock.ptr("foo"),
+            property: mock.ptr("bar"),
+        };
+
+        assert_expr!(src, expected);
+    }
 }

--- a/ratel/src/parser/expression.rs
+++ b/ratel/src/parser/expression.rs
@@ -1234,4 +1234,37 @@ mod test {
         assert!(parse("x+++++y").is_err());
     }
 
+    #[test]
+    fn regression_asi_increments() {
+        let src = r#"x
+        ++
+        y"#;
+        let mock = Mock::new();
+
+        let expected = mock.list([
+            mock.ptr(Expression::Identifier("x")),
+            mock.ptr(PrefixExpression {
+                operator: OperatorKind::Increment,
+                operand: mock.ptr("y"),
+            }),
+        ]);
+        assert_eq!(parse(src).unwrap().body(), expected);
+    }
+
+    #[test]
+    fn regression_asi_decrements() {
+        let src = r#"x
+        --
+        y"#;
+        let mock = Mock::new();
+
+        let expected = mock.list([
+            mock.ptr(Expression::Identifier("x")),
+            mock.ptr(PrefixExpression {
+                operator: OperatorKind::Decrement,
+                operand: mock.ptr("y"),
+            }),
+        ]);
+        assert_eq!(parse(src).unwrap().body(), expected);
+    }
 }

--- a/ratel/src/parser/nested.rs
+++ b/ratel/src/parser/nested.rs
@@ -246,25 +246,6 @@ const SEQ: NestedHandler = Some(|par, left| {
     })
 });
 
-const INC: NestedHandler = Some(|par, left| {
-    let end = par.lexer.end();
-    par.lexer.consume();
-
-    par.alloc_at_loc(left.start, end, PostfixExpression {
-        operator: OperatorKind::Increment,
-        operand: left,
-    })
-});
-
-const DEC: NestedHandler = Some(|par, left| {
-    let end = par.lexer.end();
-    par.lexer.consume();
-
-    par.alloc_at_loc(left.start, end, PostfixExpression {
-        operator: OperatorKind::Decrement,
-        operand: left,
-    })
-});
 
 const COND: NestedHandler = Some(|par, left| {
     par.lexer.consume();
@@ -343,6 +324,52 @@ const TPLE: NestedHandler = Some(|par, left| {
     par.tagged_template_expression(left)
 });
 
+macro_rules! postfix {
+    ($name:ident => $op:ident) => {
+        const $name: NestedHandler = {
+            fn handler<'ast>(par: &mut Parser<'ast>, left: ExpressionNode<'ast>) -> ExpressionNode<'ast> {
+                let end = par.lexer.end();
+                par.lexer.consume();
+
+                if !left.is_lvalue() {
+                    par.error::<()>();
+                }
+
+                par.alloc_at_loc(left.start, end, PostfixExpression {
+                    operator: $op,
+                    operand: left,
+                })
+            }
+
+            Some(handler)
+        };
+    }
+}
+
+macro_rules! assign {
+    ($name:ident => $op:ident) => {
+        const $name: NestedHandler = {
+            fn handler<'ast>(par: &mut Parser<'ast>, left: ExpressionNode<'ast>) -> ExpressionNode<'ast> {
+                par.lexer.consume();
+
+                if !left.is_lvalue() {
+                    par.error::<()>();
+                }
+
+                let right = par.expression::<B1>();
+
+                par.alloc_at_loc(left.start, right.end, BinaryExpression {
+                    operator: $op,
+                    left,
+                    right,
+                })
+            }
+
+            Some(handler)
+        };
+    }
+}
+
 macro_rules! binary {
     ($name:ident, $bp:ident => $op:ident) => {
         const $name: NestedHandler = {
@@ -363,19 +390,23 @@ macro_rules! binary {
     }
 }
 
-binary!(ASGN , B1  => Assign);
-binary!(ADDA , B1  => AddAssign);
-binary!(SUBA , B1  => SubtractAssign);
-binary!(EXPA , B1  => ExponentAssign);
-binary!(MULA , B1  => MultiplyAssign);
-binary!(DIVA , B1  => DivideAssign);
-binary!(REMA , B1  => RemainderAssign);
-binary!(BSLA , B1  => BSLAssign);
-binary!(BSRA , B1  => BSRAssign);
-binary!(UBSA , B1  => UBSRAssign);
-binary!(BWAA , B1  => BitAndAssign);
-binary!(XORA , B1  => BitXorAssign);
-binary!(BORA , B1  => BitOrAssign);
+postfix!(INC => Increment);
+postfix!(DEC => Decrement);
+
+assign!(ASGN => Assign);
+assign!(ADDA => AddAssign);
+assign!(SUBA => SubtractAssign);
+assign!(EXPA => ExponentAssign);
+assign!(MULA => MultiplyAssign);
+assign!(DIVA => DivideAssign);
+assign!(REMA => RemainderAssign);
+assign!(BSLA => BSLAssign);
+assign!(BSRA => BSRAssign);
+assign!(UBSA => UBSRAssign);
+assign!(BWAA => BitAndAssign);
+assign!(XORA => BitXorAssign);
+assign!(BORA => BitOrAssign);
+
 binary!(OR   , B5  => LogicalOr);
 binary!(AND  , B6  => LogicalAnd);
 binary!(BWOR , B7  => BitwiseOr);

--- a/ratel/src/parser/nested.rs
+++ b/ratel/src/parser/nested.rs
@@ -5,7 +5,7 @@ use lexer::Token::*;
 use ast::{NodeList, OperatorKind, Expression, ExpressionNode};
 use ast::expression::*;
 use ast::OperatorKind::*;
-
+use lexer::Asi;
 
 const TOTAL_TOKENS: usize = 108;
 
@@ -440,6 +440,12 @@ impl<'ast> Parser<'ast> {
         B: BindingPower
     {
         while let Some(handler) = B::handler(self.lexer.token) {
+
+            match self.asi() {
+                Asi::ImplicitSemicolon |
+                Asi::ExplicitSemicolon => break,
+                _                      => {}
+            };
             left = handler(self, left);
         }
 

--- a/ratel/src/parser/statement.rs
+++ b/ratel/src/parser/statement.rs
@@ -206,7 +206,6 @@ impl<'ast> Parser<'ast> {
 
         let expression = self.alloc_at_loc(start, end, label);
         let expression = self.nested_expression::<ANY>(expression);
-
         self.expect_semicolon();
 
         self.alloc_at_loc(start, expression.end, expression)

--- a/ratel/src/parser/statement.rs
+++ b/ratel/src/parser/statement.rs
@@ -206,6 +206,7 @@ impl<'ast> Parser<'ast> {
 
         let expression = self.alloc_at_loc(start, end, label);
         let expression = self.nested_expression::<ANY>(expression);
+
         self.expect_semicolon();
 
         self.alloc_at_loc(start, expression.end, expression)


### PR DESCRIPTION
- `is_lvalue` checks in the new macros `assign` and `postfix` whether `left` is Identifier, Member, Object, Array or Spread
- Replacing `OperatorKind::is_word` with `OperatorKind::category`.

Addresses issue #78.