### PR TITLE
CI: Make clippy optional

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,8 +25,7 @@ before_install:
   - nvm use 8
 
 before_script:
-  - rustup install $CLIPPY_TOOLCHAIN
-  - rustup component add clippy-preview --toolchain=$CLIPPY_TOOLCHAIN
+  - if [ $TRAVIS_RUST_VERSION = $CLIPPY_TOOLCHAIN ]; then rustup component add clippy-preview --toolchain=$CLIPPY_TOOLCHAIN; fi
   - curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh -s -- -f
 
 script: ./test.sh

--- a/test.sh
+++ b/test.sh
@@ -1,10 +1,14 @@
+set -e
+
 echo ""
 echo ""
 echo "CHECKING: clippy"
 echo "#######################"
 echo ""
 
-cargo +$CLIPPY_TOOLCHAIN clippy || exit
+if [ $TRAVIS_RUST_VERSION = $CLIPPY_TOOLCHAIN ]; then
+  cargo +$CLIPPY_TOOLCHAIN clippy
+fi
 
 echo ""
 echo ""
@@ -12,7 +16,7 @@ echo "TESTING: ratel + crates"
 echo "#######################"
 echo ""
 
-cargo test || exit
+cargo test
 
 echo ""
 echo ""
@@ -21,6 +25,6 @@ echo "############"
 echo ""
 
 cd ffi
-npm i || exit
-npm test || exit
+npm i
+npm test
 cd ..


### PR DESCRIPTION
Nightly & Clippy are both subject to breakage. Since they're not stable enough to rely on, let's make it optional for the meanwhile.